### PR TITLE
Fixed Oracle concat error in Overview of students page

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -96,8 +96,8 @@ function block_completion_progress_course_submissions($courseid) {
 
     // Queries to deliver instance IDs of activities with submissions by user.
     $queries = array (
-        'assign' => "SELECT CONCAT(s.userid, '-', c.id)
-                       FROM {assign_submission} s, {assign} a, {modules} m, {course_modules} c
+        'assign' => "SELECT ". $DB->sql_concat('s.userid', ''-'', 'c.id') .
+                       "FROM {assign_submission} s, {assign} a, {modules} m, {course_modules} c
                       WHERE s.latest = 1
                         AND s.status = 'submitted'
                         AND s.assignment = a.id
@@ -105,8 +105,8 @@ function block_completion_progress_course_submissions($courseid) {
                         AND m.name = 'assign'
                         AND m.id = c.module
                         AND c.instance = a.id",
-        'workshop' => "SELECT CONCAT(s.authorid, '-', c.id)
-                         FROM {workshop_submissions} s, {workshop} w, {modules} m, {course_modules} c
+        'workshop' => "SELECT ". $DB->sql_concat('s.authorid', ''-'', 'c.id') .
+                         "FROM {workshop_submissions} s, {workshop} w, {modules} m, {course_modules} c
                         WHERE s.workshopid = w.id
                           AND w.course = :courseid
                           AND m.name = 'workshop'


### PR DESCRIPTION
When trying to access as teacher to Overview of students page (moodle/blocks/completion_progress/overview.php), with Oracle installations we get the following error:

```
Error reading from database

More information about this error

  × Debug info: ORA-00909: invalid number of arguments
SELECT CONCAT(s.userid, '-', c.id)
FROM m2assign_submission s, m2assign a, m2modules m, m2course_modules c
WHERE s.latest = 1
AND s.status = 'submitted'
AND s.assignment = a.id
AND a.course = :o_courseid
AND m.name = 'assign'
AND m.id = c.module
AND c.instance = a.id
[array (
'o_courseid' => 'XXX',
)]
Error code: dmlreadexception
  × Stack trace:
line 474 of /lib/dml/moodle_database.php: dml_read_exception thrown
line 276 of /lib/dml/oci_native_moodle_database.php: call to moodle_database->query_end()
line 1201 of /lib/dml/oci_native_moodle_database.php: call to oci_native_moodle_database->query_end()
line 118 of /blocks/completion_progress/lib.php: call to oci_native_moodle_database->get_records_sql()
line 182 of /blocks/completion_progress/overview.php: call to block_completion_progress_course_submissions()
```

The following patch solves this problem for Oracle and should also work with other databases because uses the Moodle standard concat function (it has been tested with Oracle and with MySQL).
