### PR TITLE
Fix memory leak (get_fast_modinfo function inside loop)

### DIFF
--- a/block_completion_progress.php
+++ b/block_completion_progress.php
@@ -105,6 +105,8 @@ class block_completion_progress extends block_base {
     public function get_content() {
         global $USER, $COURSE, $CFG, $OUTPUT, $DB;
 
+        $modinfo = get_fast_modinfo($COURSE->id);
+
         // If content has already been generated, don't waste time generating it again.
         if ($this->content !== null) {
             return $this->content;
@@ -160,7 +162,7 @@ class block_completion_progress extends block_base {
                     foreach ($blockinstances as $blockid => $blockinstance) {
                         $blockinstance->config = unserialize(base64_decode($blockinstance->configdata));
                         $blockinstance->activities = block_completion_progress_get_activities($course->id, $blockinstance->config);
-                        $blockinstance->activities = block_completion_progress_filter_visibility($blockinstance->activities,
+                        $blockinstance->activities = block_completion_progress_filter_visibility($modinfo, $blockinstance->activities,
                                                          $USER->id, $course->id);
                         $blockcontext = CONTEXT_BLOCK::instance($blockid);
                         if (
@@ -241,7 +243,7 @@ class block_completion_progress extends block_base {
 
             // Check if any activities/resources have been created.
             $activities = block_completion_progress_get_activities($COURSE->id, $this->config);
-            $activities = block_completion_progress_filter_visibility($activities, $USER->id, $COURSE->id);
+            $activities = block_completion_progress_filter_visibility($modinfo, $activities, $USER->id, $COURSE->id);
             if (empty($activities)) {
                 if (has_capability('moodle/block:edit', $this->context)) {
                     $this->content->text .= get_string('no_activities_config_message', 'block_completion_progress');

--- a/lib.php
+++ b/lib.php
@@ -250,15 +250,15 @@ function block_completion_progress_compare_times($a, $b) {
 /**
  * Filters activities that a user cannot see due to grouping constraints
  *
+ * @param mixed  $modinfo Information about the course modules
  * @param array  $activities The possible activities that can occur for modules
  * @param array  $userid The user's id
  * @param string $courseid the course for filtering visibility
  * @return array The array with restricted activities removed
  */
-function block_completion_progress_filter_visibility($activities, $userid, $courseid) {
+function block_completion_progress_filter_visibility($modinfo, $activities, $userid, $courseid) {
     global $CFG;
     $filteredactivities = array();
-    $modinfo = get_fast_modinfo($courseid, $userid);
     $coursecontext = CONTEXT_COURSE::instance($courseid);
 
     // Keep only activities that are visible.

--- a/overview.php
+++ b/overview.php
@@ -257,6 +257,8 @@ if ($sortbyprogress) {
     $enduser = $enddisplay;
 }
 
+$modinfo = get_fast_modinfo($course->id);
+
 // Build array of user information.
 $rows = array();
 for ($i = $startuser; $i < $enduser; $i++) {
@@ -271,7 +273,9 @@ for ($i = $startuser; $i < $enduser; $i++) {
     } else {
         $lastonline = userdate($users[$i]->lastonlinetime);
     }
-    $useractivities = block_completion_progress_filter_visibility($activities, $users[$i]->id, $course->id);
+
+    $useractivities = block_completion_progress_filter_visibility($modinfo, $activities, $users[$i]->id, $course->id);
+
     if (!empty($useractivities)) {
         $completions = block_completion_progress_completions($useractivities, $users[$i]->id, $course, $users[$i]->submissions);
         $progressbar = block_completion_progress_bar($useractivities, $completions, $config, $users[$i]->id, $course->id,


### PR DESCRIPTION
Hi Michael

The "get_fast_modinfo" function inside the "block_completion_progress_filter_visibility" function results in high memory usage in the view "/blocks/completion_progress/overview.php":
https://www.screencast.com/t/YoeJhqoA45

I moved the "get_fast_modinfo" function outside the "block_completion_progress_filter_visibility" function and passed $modinfo as a variable instead.

Please accept this pull request to solve the problem.