### PR TITLE
Fix unit tests for 3.4

### DIFF
--- a/tests/base_test.php
+++ b/tests/base_test.php
@@ -94,7 +94,6 @@ class block_completion_progress_base_testcase extends advanced_testcase {
         // Add a block.
         $context = CONTEXT_COURSE::instance($this->course->id);
         $blockinfo = [
-          'blockname' => 'completion_progress',
           'parentcontextid' => $context->id,
           'pagetypepattern' => 'course-view-*',
           'showinsubcontexts' => 0,
@@ -105,7 +104,8 @@ class block_completion_progress_base_testcase extends advanced_testcase {
                           'NzVGl0bGUiO3M6MDoiIjtzOjE4OiJhY3Rpdml0aWVzaW5jbHVkZWQiO3M6MTg6ImFjdGl2aXR5Y29tcGxldGlvbiI7fQ=='
         ];
 
-        $blockinstanceid = $DB->insert_record('block_instances', (object) $blockinfo);
+        $blockinstance = $this->getDataGenerator()->create_block('completion_progress', $blockinfo);
+        $blockinstanceid = $blockinstance->id;
 
         $assign = $this->create_instance([
           'submissiondrafts' => 0,

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * block_completion_progress data generator
+ *
+ * @package    block_completion_progress
+ * @category   test
+ * @copyright  2018 Michael Aherne
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+
+/**
+ * Completion progress block data generator class
+ *
+ * @package    block_completion_progress
+ * @category   test
+ * @copyright  2018 Michael Aherne
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class block_completion_progress_generator extends testing_block_generator {
+
+}


### PR DESCRIPTION
Hi Michael, here's a patch to fix the unit tests, which are failing on 3.4 due to the new timecreated and timemodified columns in block_instances (not null). It introduces a generator, so the tests should still pass on previous versions that don't have these columns. Cheers, Michael.