### PR TITLE
Fix for issue #35, broken links for label items

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -478,7 +478,9 @@ function block_completion_progress_bar($activities, $completions, $config, $user
             $celloptions['style'] .= $colours['futureNotCompleted_colour'].';';
             $cellcontent = $OUTPUT->pix_icon('blank', '', 'block_completion_progress');
         }
-        if (!empty($activity['available']) || $simple) {
+        if (empty($activity['link'])) {
+            $celloptions['style'] .= 'cursor: unset;';
+        } else if (!empty($activity['available']) || $simple) {
             $celloptions['onclick'] = 'document.location=\''.$activity['link'].'\';';
         } else if (!empty($activity['link'])) {
             $celloptions['style'] .= 'cursor: not-allowed;';


### PR DESCRIPTION
I put in a check if the activity of a cell has a link before setting the onclick property. If there is no link, then leave the cursor unset, indicating there is no link.