### PR TITLE
Adding missing notes/lib.php requirement, fixes #42

### DIFF
--- a/overview.php
+++ b/overview.php
@@ -26,6 +26,7 @@
 // Include required files.
 require_once(dirname(__FILE__) . '/../../config.php');
 require_once($CFG->dirroot.'/blocks/completion_progress/lib.php');
+require_once($CFG->dirroot.'/notes/lib.php');
 require_once($CFG->libdir.'/tablelib.php');
 
 const USER_SMALL_CLASS = 20;   // Below this is considered small.


### PR DESCRIPTION
Adding the missing notes/lib.php library file fixes not being able to call note_get_state_names(); mentioned in #42 