### PR TITLE
Prevent long mouse_over_prompt from being cut.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -139,6 +139,9 @@
     padding: 0;
     margin: 5px;
 }
+.block_completion_progress .progressEventInfo {
+    white-space: pre-wrap;
+}
 .dir-rtl .block_completion_progress .progressEventInfo,
 .dir-rtl .block_completion_progress .progressPercentage {
     text-align: right;


### PR DESCRIPTION
In some languages, e.g. german the mouse_over_prompt text is quite long and therefore it's cut off.

<img width="369" alt="pre-wrap" src="https://user-images.githubusercontent.com/377279/77847679-40518d00-71bf-11ea-9fae-b065cccd4740.png">

It would be great if it could wrap.