### PR TITLE
Adding title for "Add a block" chooser.

### DIFF
--- a/block_completion_progress.php
+++ b/block_completion_progress.php
@@ -41,7 +41,7 @@ class block_completion_progress extends block_base {
      * @return void
      */
     public function init() {
-        $this->title = '';
+        $this->title = get_string('pluginname', 'block_completion_progress');
     }
 
     /**


### PR DESCRIPTION
Without this addition the block would always appear as first one since the title is "" and therefore leading in alphabetical order.
<img width="503" alt="titlelacking" src="https://user-images.githubusercontent.com/377279/77852904-61c37080-71e1-11ea-9316-e989b2b4f1e1.png">
